### PR TITLE
Verify all possible hosts that match web nav

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -15610,7 +15610,9 @@ public class PackageManagerService extends IPackageManager.Stub {
                 final int verificationId = mIntentFilterVerificationToken++;
                 for (PackageParser.Activity a : pkg.activities) {
                     for (ActivityIntentInfo filter : a.intents) {
-                        if (filter.handlesWebUris(true) && needsNetworkVerificationLPr(filter)) {
+                        // Run verification against hosts mentioned in any web-nav intent filter,
+                        // even if the filter matches non-web schemes as well
+                        if (filter.handlesWebUris(false) && needsNetworkVerificationLPr(filter)) {
                             if (DEBUG_DOMAIN_VERIFICATION) Slog.d(TAG,
                                     "Verification needed for IntentFilter:" + filter.toString());
                             mIntentFilterVerifier.addOneIntentFilterVerification(


### PR DESCRIPTION
Even if an <intent-filter> matches non-web schemes in addition to http
or https, make sure to include its cited hosts in the autoVerify
evaluation.

Bug: 150038428
Test: atest OsHostTests#testIntentFilterHostValidation
Change-Id: If9ef0fc53d96e6581c56d86f89fe63bc9a5fb89a
Merged-In: If9ef0fc53d96e6581c56d86f89fe63bc9a5fb89a
(cherry picked from commit 1fba0f897f276d5d47962534867e764da8061105)
(cherry picked from commit a481c86cd3742c7792f8607c004e0eeb4016b894)